### PR TITLE
Merge No conversation limit update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 I wanted to use GPT-4o-mini like I would normally do on the website (for free), but just doing it through API calls.
 
   
-This is done by interacting with DuckDuckGo's AI chat functionality. Previously, this was achieved using the DuckDuckGo Python library, but the dependency has been removed. Now, the chat interactions are handled directly through HTTP requests instead.
+This is done by interacting with DuckDuckGo's AI chat functionality. Previously, this was achieved using the DuckDuckGo Python library (using the [chat() function](https://pypi.org/project/duckduckgo-search)), but the dependency has been removed due to its limitations. Now, the chat interactions are handled directly through HTTP requests instead.
   
 **Note:** I know it works with the Continue.dev VSCode extension and Ollama Open Web UI, have not tested it on anything else, so YMMV
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,12 @@ This is done by interacting with DuckDuckGo's AI chat functionality. Previously,
   
 **Note:** I know it works with the Continue.dev VSCode extension and Ollama Open Web UI, have not tested it on anything else, so YMMV
 
-In my time making this API I found some limitations from using the DuckDuckGo Python Library:
+In my time making this API I found some limitations from interacting with DuckDuckGo's AI chat:
 
 
 1. Cannot send images
 
-    1a. Havent figured this one out yet
-
-3. Context length for a given conversation session is up to 20k characters, this is because your conversation history is appended in each message you send. DuckDuckGo Chat's frontend does something similar but without sacrificing on character length (don't know how), because each message is treated as a new chat session for what I assume is for privacy reasons.
-
-    2a. As a way to work within the bounds of this, the messages are compressed by removing whitespace in order to retain more characters. Giving it a "lengthier" context. Once you approach the context limit, old messages start getting pruned from its context.
+    1a. Havent figured this one out yet (probably never will)
 
 *Do not expect frequent updates, I'll be using this until it breaks pretty much.*
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ curl -X POST "http://localhost:1337/v1/chat/completions/non-streaming" \
 In cases where you want to continue having a conversion you can keep note of the conversation_id generated, for instance:
 
   
-You send your initial message (using curl as an example)
+You send your initial message (using curl as an example): **use non-streaming always**
 
  ```
- curl -X POST "http://localhost:1337/v1/chat/completions" \
+ curl -X POST "http://localhost:1337/v1/chat/completions/non-streaming" \
 -H "Content-Type: application/json" \
 -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Tell me a joke"}]}' \
 -H "Accept: text/event-stream"
@@ -126,43 +126,40 @@ You send your initial message (using curl as an example)
 You receive:
 ```
 {
+  "id": "1cecdf45-df73-431b-884b-6d233b5511c7", <========= TAKE NOTE OF THIS
+  "object": "chat.completion",
+  "created": 1726725779,
   "model": "gpt-4o-mini",
-  "messages": [
+  "choices": [
     {
-      "role": "user",
-      "content": "Tell me a joke"
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Why did the scarecrow win an award? \n\nBecause he was outstanding in his field!"
+      },
+      "finish_reason": "stop"
     }
   ],
-  "data": {
-    "id": "ca218944-3bc0-41c6-8b9e-37ad52407bb9",   <========== TAKE NOTE OF THIS
-    "object": "chat.completion.chunk",
-    "created": 1726380683,
-    "model": "gpt-4o-mini",
-    "choices": [
-      {
-        "index": 0,
-        "delta": {
-          "role": "assistant",
-          "content": "Why did the scarecrow win an award? \n\nBecause he was outstanding in his field!"
-        },
-        "finish_reason": null
-      }
-    ]
-  },
-  "data_status": "[DONE]"
+  "usage": {
+    "prompt_tokens": 14,
+    "completion_tokens": 78,
+    "total_tokens": 92
+  }
 }
 ```
 
 With the response received, you can send a follow-up question with the conversation_id appended at the end:
 
-
-
 ```
-curl -X POST http://127.0.0.1:1337/v1/chat/completions \
+curl -X POST http://127.0.0.1:1337/v1/chat/completions/non-streaming \
 -H "Content-Type: application/json" \
--d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Tell me another"}], "conversation_id": "ca218944-3bc0-41c6-8b9e-37ad52407bb9"}'
+-d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Tell me another"}], "conversation_id": "1cecdf45-df73-431b-884b-6d233b5511c7"}'
 ```
 
 #### Deleting a conversation
 
-``curl -X DELETE http://127.0.0.1:1337/v1/conversations/ca218944-3bc0-41c6-8b9e-37ad52407bb9``
+``curl -X DELETE http://127.0.0.1:1337/v1/conversations/1cecdf45-df73-431b-884b-6d233b5511c7``
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 I wanted to use GPT-4o-mini like I would normally do on the website (for free), but just doing it through API calls.
 
   
-This is done by using the DuckDuckGo Python library, and using its [chat() function](https://pypi.org/project/duckduckgo-search), which allows you to use AI models, like GPT4o Mini and Claude 3 Haiku. From there I made an OpenAI Compatible API to make sure I can use it in other services.
-
+This is done by interacting with DuckDuckGo's AI chat functionality. Previously, this was achieved using the DuckDuckGo Python library, but the dependency has been removed. Now, the chat interactions are handled directly through HTTP requests instead.
   
 **Note:** I know it works with the Continue.dev VSCode extension and Ollama Open Web UI, have not tested it on anything else, so YMMV
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ anyio==4.4.0
 certifi==2024.8.30
 charset-normalizer==3.3.2
 click==8.1.7
-duckduckgo_search==6.2.6
 exceptiongroup==1.2.2
 fastapi==0.112.0
 h11==0.14.0

--- a/server.py
+++ b/server.py
@@ -119,7 +119,8 @@ async def list_models():
     models = [
         ModelInfo(id="gpt-4o-mini"),
         ModelInfo(id="claude-3-haiku"),
-        ModelInfo(id="mixtral-8x7b")
+        ModelInfo(id="mixtral-8x7b"),
+        ModelInfo(id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo")
     ]
     return {"data": models, "object": "list"}
 
@@ -132,7 +133,7 @@ async def chat_completion(request: ChatCompletionRequest):
 
     conversation_history = conversations.get(conversation_id, [])
     conversation_history.extend(request.messages)
-    
+
     async def generate():
         try:
             async for chunk in chat_with_duckduckgo(" ".join([msg.content for msg in request.messages]), request.model, conversation_history):

--- a/server.py
+++ b/server.py
@@ -7,7 +7,6 @@ import logging
 import uuid
 import time
 import json
-import asyncio
 import httpx
 
 app = FastAPI()

--- a/server.py
+++ b/server.py
@@ -2,14 +2,13 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Dict, Optional
-from duckduckgo_search import DDGS
 from fastapi.responses import JSONResponse, StreamingResponse
 import logging
 import uuid
 import time
 import json
-import re
 import asyncio
+import httpx
 
 app = FastAPI()
 
@@ -48,46 +47,71 @@ class ChatCompletionResponse(BaseModel):
 
 # Store active conversations
 conversations: Dict[str, List[ChatMessage]] = {}
+current_vqd_token = ""
 
-def compress_text(text):
-    original_length = len(text)
-    text = re.sub(r'\s+', ' ', text).strip()
-    compressed_length = len(text)
-    compression_ratio = (original_length - compressed_length) / original_length * 100 if original_length else 0
-    logging.info(f"Compressed text from {original_length} to {compressed_length} characters. Compression ratio: {compression_ratio:.2f}%")
-    return text
+async def update_vqd_token():
+    global current_vqd_token
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.get("https://duckduckgo.com/country.json")
+            headers = {"x-vqd-accept": "1"}
+            response = await client.get("https://duckduckgo.com/duckchat/v1/status", headers=headers)
+            if response.status_code == 200:
+                current_vqd_token = response.headers.get("x-vqd-4", current_vqd_token)
+                logging.info(f"Updated x-vqd-4 token: {current_vqd_token}")
+            else:
+                logging.warning(f"Failed to update x-vqd-4 token. Status code: {response.status_code}")
+        except Exception as e:
+            logging.error(f"Error updating x-vqd-4 token: {str(e)}")
 
-def manage_conversation_context(conversations, conversation_id, new_messages, max_chars=20000): # turns out its 20k!
-    current_conversation = conversations.get(conversation_id, [])
-    
-    initial_char_count = sum(len(m.content) for m in current_conversation)
-    initial_message_count = len(current_conversation)
-    logging.info(f"Initial state for conversation {conversation_id}: {initial_char_count} characters, {initial_message_count} messages")
-    
-    for message in new_messages:
-        message.content = compress_text(message.content)
-    
-    current_conversation.extend(new_messages)
-    
-    total_chars = sum(len(m.content) for m in current_conversation)
-    
-    removed_messages = 0
-    while total_chars > max_chars:
-        if current_conversation:
-            removed_msg = current_conversation.pop(0)
-            removed_messages += 1
-            logging.info(f"Removed message: {removed_msg.role} - {removed_msg.content[:50]}...")
-        else:
-            break  
-        total_chars = sum(len(m.content) for m in current_conversation)
-    
-    final_char_count = total_chars
-    final_message_count = len(current_conversation)
-    logging.info(f"Final state for conversation {conversation_id}: {final_char_count} characters, {final_message_count} messages")
-    logging.info(f"Removed {removed_messages} messages to stay within the limit")
-    
-    conversations[conversation_id] = current_conversation
-    return current_conversation
+async def chat_with_duckduckgo(query: str, model: str, conversation_history: List[ChatMessage]):
+    global current_vqd_token
+
+    await update_vqd_token()
+
+    user_messages = [{"role": msg.role, "content": msg.content} for msg in conversation_history if msg.role == "user"]
+    payload = {
+        "messages": user_messages,
+        "model": model
+    }
+
+    headers = {
+        "x-vqd-4": current_vqd_token,
+        "Content-Type": "application/json"
+    }
+
+    logging.info(f"Sending payload to DuckDuckGo: {json.dumps(payload)}")
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post("https://duckduckgo.com/duckchat/v1/chat", json=payload, headers=headers)
+            if response.status_code == 200:
+                full_response = ""
+                async for line in response.aiter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:].strip()
+                        if data == "[DONE]":
+                            break
+                        try:
+                            json_data = json.loads(data)
+                            message = json_data.get("message", "")
+                            full_response += message
+                            yield message
+                        except json.JSONDecodeError:
+                            logging.warning(f"Failed to parse JSON: {data}")
+                logging.info(f"Full response from DuckDuckGo: {full_response}")
+            else:
+                logging.error(f"Error response from DuckDuckGo. Status code: {response.status_code}")
+                raise HTTPException(status_code=response.status_code, detail=f"Error communicating with DuckDuckGo: {response.text}")
+        except httpx.HTTPStatusError as e:
+            logging.error(f"HTTP error occurred: {str(e)}")
+            raise HTTPException(status_code=e.response.status_code, detail=str(e))
+        except httpx.RequestError as e:
+            logging.error(f"Request error occurred: {str(e)}")
+            raise HTTPException(status_code=500, detail=str(e))
+        except Exception as e:
+            logging.error(f"Unexpected error in chat_with_duckduckgo: {str(e)}")
+            raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
 @app.get("/v1/models")
 async def list_models():
@@ -102,31 +126,16 @@ async def list_models():
 @app.post("/v1/chat/completions")
 async def chat_completion(request: ChatCompletionRequest):
     conversation_id = request.conversation_id or str(uuid.uuid4())
-    
-    logging.info(f"Received streaming request for conversation {conversation_id}")
-    logging.debug(f"Request content: {request.model_dump_json(exclude_unset=True)}")
-    
-    managed_conversation = manage_conversation_context(conversations, conversation_id, request.messages)
-    
-    history_json = {
-        "conversation_id": conversation_id,
-        "messages": [message.model_dump() for message in managed_conversation]
-    }
-    logging.info(f"Appending conversation history: {json.dumps(history_json)}")
-    
 
-    query = " ".join([msg.content for msg in managed_conversation if msg.role != "system"])
-    logging.info(f"Generated query for conversation {conversation_id}: {len(query)} characters")
+    logging.info(f"Received streaming request for conversation {conversation_id}")
+    logging.info(f"Request: {request.model_dump()}")
+
+    conversation_history = conversations.get(conversation_id, [])
+    conversation_history.extend(request.messages)
     
     async def generate():
         try:
-            logging.info(f"Sending query to DuckDuckGo for conversation {conversation_id}")
-            results = DDGS().chat(query, model=request.model)
-            logging.info(f"Received response from DuckDuckGo for conversation {conversation_id}: {len(results)} characters")
-    
-            chunk_size = 10  # 10 chars per sec is a good rate for streaming
-            for i in range(0, len(results), chunk_size):
-                chunk = results[i:i+chunk_size]
+            async for chunk in chat_with_duckduckgo(" ".join([msg.content for msg in request.messages]), request.model, conversation_history):
                 response = {
                     "id": conversation_id,
                     "object": "chat.completion.chunk",
@@ -143,49 +152,30 @@ async def chat_completion(request: ChatCompletionRequest):
                         }
                     ]
                 }
-                logging.debug(f"Streaming chunk for conversation {conversation_id}: {chunk}")
                 yield f"data: {json.dumps(response)}\n\n"
-                await asyncio.sleep(0.1)  # simulate streaming
-
-            manage_conversation_context(conversations, conversation_id, [ChatMessage(role="assistant", content=results)])
 
             yield "data: [DONE]\n\n"
-            logging.info(f"Completed streaming response for conversation {conversation_id}")
         except Exception as e:
-            logging.error(f"Exception occurred during streaming for conversation {conversation_id}: {str(e)}")
-            error_response = {
-                "error": {
-                    "message": str(e),
-                    "type": "internal_error",
-                    "code": 500
-                }
-            }
-            yield f"data: {json.dumps(error_response)}\n\n"
-    
+            logging.error(f"Error during streaming: {str(e)}")
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
     return StreamingResponse(generate(), media_type="text/event-stream")
 
 @app.post("/v1/chat/completions/non-streaming")
 async def chat_completion_non_streaming(request: ChatCompletionRequest):
     conversation_id = request.conversation_id or str(uuid.uuid4())
-    
+
     logging.info(f"Received non-streaming request for conversation {conversation_id}")
-    logging.debug(f"Request content: {request.model_dump_json(exclude_unset=True)}")
-    
-    managed_conversation = manage_conversation_context(conversations, conversation_id, request.messages)
-    
-    history_json = {
-        "conversation_id": conversation_id,
-        "messages": [message.model_dump() for message in managed_conversation]
-    }
-    logging.info(f"Appending conversation history: {json.dumps(history_json)}")
-    
-    query = " ".join([msg.content for msg in managed_conversation if msg.role != "system"])
-    logging.info(f"Generated query for conversation {conversation_id}: {len(query)} characters")
-    
+    logging.info(f"Request: {request.model_dump()}")
+
+    conversation_history = conversations.get(conversation_id, [])
+    conversation_history.extend(request.messages)
+
     try:
-        logging.info(f"Sending query for conversation {conversation_id}")
-        results = DDGS().chat(query, model=request.model)
-        logging.info(f"Generated response for conversation {conversation_id}: {len(results)} characters")
+        full_response = ""
+        async for chunk in chat_with_duckduckgo(" ".join([msg.content for msg in request.messages]), request.model, conversation_history):
+            full_response += chunk
+        
         response = {
             "id": conversation_id,
             "object": "chat.completion",
@@ -196,21 +186,21 @@ async def chat_completion_non_streaming(request: ChatCompletionRequest):
                     "index": 0,
                     "message": {
                         "role": "assistant",
-                        "content": results
+                        "content": full_response
                     },
                     "finish_reason": "stop"
                 }
             ],
             "usage": {
-                "prompt_tokens": len(query),
-                "completion_tokens": len(results),
-                "total_tokens": len(query) + len(results)
+                "prompt_tokens": sum(len(msg.content) for msg in conversation_history),
+                "completion_tokens": len(full_response),
+                "total_tokens": sum(len(msg.content) for msg in conversation_history) + len(full_response)
             }
         }
 
-        manage_conversation_context(conversations, conversation_id, [ChatMessage(role="assistant", content=results)])
-
-        logging.info(f"Sending non-streaming response for conversation {conversation_id}")
+        conversation_history.append(ChatMessage(role="assistant", content=full_response))
+        conversations[conversation_id] = conversation_history
+        
         return JSONResponse(content=response, media_type="application/json")
     except Exception as e:
         logging.error(f"Exception occurred during non-streaming response for conversation {conversation_id}: {str(e)}")

--- a/testcalls.py
+++ b/testcalls.py
@@ -40,18 +40,6 @@ def test_chat_completion():
                 conversation_id = json.loads(decoded_line.split("data: ")[1])["id"]
     print("Conversation ID captured:", conversation_id)
 
-def test_chat_completion_non_streaming():
-    headers = {"Content-Type": "application/json"}
-    payload = {
-        "model": "gpt-4o-mini",
-        "messages": [
-            {"role": "user", "content": "Tell me a joke."}
-        ]
-    }
-    response = requests.post(f"{base_url}/chat/completions/non-streaming", data=json.dumps(payload), headers=headers)
-    assert response.status_code == 200
-    print("Chat Completion (Non-Streaming):", response.json())
-
 def test_end_conversation(conversation_id):
     response = requests.delete(f"{base_url}/conversations/{conversation_id}")
     assert response.status_code == 200
@@ -62,7 +50,6 @@ def test_end_conversation(conversation_id):
 if __name__ == "__main__":
     test_list_models()
     test_chat_completion()
-    test_chat_completion_non_streaming()
     if conversation_id:
         test_end_conversation(conversation_id)
     else:


### PR DESCRIPTION
This branch completely removes the previous limitation it had of only being able to have ~20k characters for a given conversation before old messages start getting pruned. Additionally, the API no longer relies on DuckDuckGo's python library. Everything is done via http requests.

Ultimately, you can now hold a **way longer** conversation now, for as long as deemed possible. This means you can take full advantage of GPT 4o's 128k context length.