### PR TITLE
Merge rate limit improvements to main

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ urllib3==2.2.3
 uuid==1.30
 uvicorn==0.30.6
 httpx==0.27.2
+fake-useragent==1.5.1


### PR DESCRIPTION
Prior to this patch, if you used this API in more intense applications where you send constant messages -- you would eventually get hit with a rate limit error (error code 429), and wait a long time.

After some testing, you can get past this by simply switching to a different user agent. Now, the API rotates through different user agents for each query to avoid getting rate limited.

https://github.com/user-attachments/assets/0e092dc4-da7c-4375-9270-bc7aa3b72b7f

