### PR TITLE
Merge Optional Audio Generation API Routes + Reintroduce Bug Fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 ./github
 ./devcontainer
-./env
+.env
 ./site
+/__pycache__
 .README.md
 testcalls.py
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 image.sh
 /__pycache__
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 image.sh
+/__pycache__

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ curl -X POST "http://localhost:1337/v1/chat/completions" \
 In cases where you want to continue having a conversion you can keep note of the conversation_id generated, for instance:
 
   
-You send your initial message (using curl as an example): **use ``stream:false`` for readibility**
+You send your initial message (**use ``stream:false`` for readibility**):
 
  ```
 curl -X POST "http://localhost:1337/v1/chat/completions" \
@@ -165,10 +165,51 @@ curl -X POST "http://localhost:1337/v1/chat/completions" \
   "stream": false
 }'
 ```
-
 #### Deleting a conversation
 
 ``curl -X DELETE http://127.0.0.1:1337/v1/conversations/1cecdf45-df73-431b-884b-6d233b5511c7``
+
+## (Optional) Text to Speech Endpoint
+Assuming you are using the optional TTS endpoint, which uses TikTok's TTS and requires a session_id during setup, you can use this endpoint in a similar fashion to OpenAI's Speech API. This is useful for cases when you are hosting your own LLM Web UI (like Open Web UI) and want to use TTS to read its messages to you, or you want to develop or prototype an AI assistant.
+
+#### Get list of available voices
+``curl -X GET http://127.0.0.1:1337/v1/audio/speech/voices``
+
+#### Sending a message with voice generation 
+If you want to interact with an LLM and obtain a response with generated speech you can do the following:
+
+```
+curl -X POST "http://localhost:1337/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "keyless-gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "Tell me a joke"}
+    ],
+    "modalities": ["audio"],
+    "audio": {
+      "voice": "en_us_002"
+    },
+    "stream": false
+  }' | jq -r '.choices[0].message.audio.data' | base64 -d > speech.mp3
+```
+* **Only can be done with ``stream:false``**
+* A complete list of voices can be found here(placeholder)
+* ``| jq -r '.choices[0].message.audio.data' | base64 -d > speech.mp3`` (decodes the audio data from the completed response to provide an mp3 file)
+
+#### Using TTS Standalone
+It is not required to use an LLM to get TTS, you can also generate speech from your own text input.
+
+```
+curl -X POST "http://localhost:1337/v1/audio/speech" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Hello, this is a test message",
+    "voice": "en_us_002"
+  }' \
+  --output speech.mp3
+```
+
 
 
 

--- a/config.py
+++ b/config.py
@@ -5,14 +5,120 @@ MODEL_MAPPING = {
     "keyless-meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
 }
 VOICES = {
+    # English Voices - Standard
+    'en_uk_001': {'name': 'Narrator (Chris)', 'language': 'en-UK', 'category': 'standard'}, #works
+    'en_uk_003': {'name': 'UK Male 2', 'language': 'en-UK', 'category': 'standard'}, # works 
+    'en_female_emotional': {'name': 'Peaceful', 'language': 'en-US', 'category': 'standard'}, # works 
+    'en_au_001': {'name': 'Metro (Eddie)', 'language': 'en-AU', 'category': 'standard'}, # works
+    'en_au_002': {'name': 'Smooth (Alex)', 'language': 'en-AU', 'category': 'standard'}, # works
+    'en_us_002': {'name': 'Jessie', 'language': 'en-US', 'category': 'standard'}, # works
+    'en_us_006': {'name': 'Joey', 'language': 'en-US', 'category': 'standard'}, # works
+    'en_us_007': {'name': 'Professor', 'language': 'en-US', 'category': 'standard'}, # works
+    'en_us_009': {'name': 'Scientist', 'language': 'en-US', 'category': 'standard'}, # works
+    'en_us_010': {'name': 'Confidence', 'language': 'en-US', 'category': 'standard'}, # works
 
-    'en_us_ghostface': {'name': 'Ghost Face', 'language': 'en-US', 'category': 'disney'},
-    'en_us_chewbacca': {'name': 'Chewbacca', 'language': 'en-US', 'category': 'disney'},
-    'en_us_c3po': {'name': 'C3PO', 'language': 'en-US', 'category': 'disney'},
-    'en_us_stitch': {'name': 'Stitch', 'language': 'en-US', 'category': 'disney'},
-    'en_us_stormtrooper': {'name': 'Stormtrooper', 'language': 'en-US', 'category': 'disney'},
-    'en_us_rocket': {'name': 'Rocket', 'language': 'en-US', 'category': 'disney'},
-    'en_female_leota': {'name': 'Madame Leota', 'language': 'en-US', 'category': 'disney'},
-    'en_male_ghosthost': {'name': 'Ghost Host', 'language': 'en-US', 'category': 'disney'},
-    'en_male_pirate': {'name': 'Pirate', 'language': 'en-US', 'category': 'disney'},
+    # English Voices - Character
+    'en_female_samc': {'name': 'Empathetic', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_cody': {'name': 'Serious', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_narration': {'name': 'Story Teller', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_funny': {'name': 'Wacky', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_jarvis': {'name': 'Alfred', 'language': 'en-US', 'category': 'character'},  # works
+    'en_male_santa_narration': {'name': 'Author', 'language': 'en-US', 'category': 'character'}, # works
+    'en_female_betty': {'name': 'Bae', 'language': 'en-US', 'category': 'character'}, # works
+    'en_female_makeup': {'name': 'Beauty Guru', 'language': 'en-US', 'category': 'character'}, # works
+    'en_female_richgirl': {'name': 'Bestie', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_cupid': {'name': 'Cupid', 'language': 'en-US', 'category': 'character'}, # works 
+    'en_female_shenna': {'name': 'Debutante', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_ghosthost': {'name': 'Ghost Host', 'language': 'en-US', 'category': 'character'}, # works
+    'en_female_grandma': {'name': 'Grandma', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_ukneighbor': {'name': 'Lord Cringe', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_wizard': {'name': 'Magician', 'language': 'en-US', 'category': 'character'}, # works 
+    'en_male_trevor': {'name': 'Marty', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_deadpool': {'name': 'Mr. GoodGuy (Deadpool)', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_ukbutler': {'name': 'Mr. Meticulous', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_petercullen': {'name': 'Optimus Prime', 'language': 'en-US', 'category': 'character'}, # not working
+    'en_male_pirate': {'name': 'Pirate', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_santa': {'name': 'Santa', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_santa_effect': {'name': 'Santa (w/ effect)', 'language': 'en-US', 'category': 'character'}, # works
+    'en_female_pansino': {'name': 'Varsity', 'language': 'en-US', 'category': 'character'}, # works
+    'en_male_grinch': {'name': 'Trickster (Grinch)', 'language': 'en-US', 'category': 'character'}, # works
+
+    # English Voices - Disney
+    'en_us_ghostface': {'name': 'Ghostface (Scream)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_us_chewbacca': {'name': 'Chewbacca (Star Wars)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_us_c3po': {'name': 'C-3PO (Star Wars)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_us_stormtrooper': {'name': 'Stormtrooper (Star Wars)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_us_stitch': {'name': 'Stitch (Lilo & Stitch)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_us_rocket': {'name': 'Rocket (Guardians of the Galaxy)', 'language': 'en-US', 'category': 'disney'}, # works
+    'en_female_madam_leota': {'name': 'Madame Leota (Haunted Mansion)', 'language': 'en-US', 'category': 'disney'}, # works
+
+    # English Voices - Song
+    'en_male_sing_deep_jingle': {'name': 'Song: Caroler', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_m03_classical': {'name': 'Song: Classic Electric', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_f08_salut_damour': {'name': 'Song: Cottagecore (Salut d\'Amour)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_m2_xhxs_m03_christmas': {'name': 'Song: Cozy', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_f08_warmy_breeze': {'name': 'Song: Open Mic (Warmy Breeze)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_ht_f08_halloween': {'name': 'Song: Opera (Halloween)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_ht_f08_glorious': {'name': 'Song: Euphoric (Glorious)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_sing_funny_it_goes_up': {'name': 'Song: Hypetrain (It Goes Up)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_m03_lobby': {'name': 'Song: Jingle (Lobby)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_ht_f08_wonderful_world': {'name': 'Song: Melodrama (Wonderful World)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_ht_f08_newyear': {'name': 'Song: NYE 2023', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_sing_funny_thanksgiving': {'name': 'Song: Thanksgiving', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_m03_sunshine_soon': {'name': 'Song: Toon Beat (Sunshine Soon)', 'language': 'en-US', 'category': 'song'}, # works
+    'en_female_f08_twinkle': {'name': 'Song: Pop Lullaby', 'language': 'en-US', 'category': 'song'}, # works
+    'en_male_m2_xhxs_m03_silly': {'name': 'Song: Quirky Time', 'language': 'en-US', 'category': 'song'}, # works
+
+    # French Voices
+    'fr_001': {'name': 'French Male 1', 'language': 'fr-FR', 'category': 'standard'}, # not working
+    'fr_002': {'name': 'French Male 2', 'language': 'fr-FR', 'category': 'standard'}, # not working
+
+    # German Voices
+    'de_001': {'name': 'German Female', 'language': 'de-DE', 'category': 'standard'}, # not working
+    'de_002': {'name': 'German Male', 'language': 'de-DE', 'category': 'standard'}, # not working
+
+    # Indonesian Voices
+    'id_male_darma': {'name': 'Darma', 'language': 'id-ID', 'category': 'standard'}, # works
+    'id_female_icha': {'name': 'Icha', 'language': 'id-ID', 'category': 'standard'}, # works
+    'id_female_noor': {'name': 'Noor', 'language': 'id-ID', 'category': 'standard'}, # not working
+    'id_male_putra': {'name': 'Putra', 'language': 'id-ID', 'category': 'standard'}, # works
+
+    # Italian Voices
+    'it_male_m18': {'name': 'Italian Male', 'language': 'it-IT', 'category': 'standard'}, # works
+
+    # Japanese Voices
+    'jp_001': {'name': 'Miho (美穂)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_003': {'name': 'Keiko (恵子)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_005': {'name': 'Sakura (さくら)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_006': {'name': 'Naoki (直樹)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_male_osada': {'name': 'モリスケ (Morisuke)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_male_matsuo': {'name': 'モジャオ (Matsuo)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+    'jp_female_machikoriiita': {'name': 'まちこりーた (Machikoriiita)', 'language': 'ja-JP', 'category': 'standard'}, # works
+    'jp_male_matsudake': {'name': 'マツダ家の日常 (Matsudake)', 'language': 'ja-JP', 'category': 'standard'}, # works 
+    'jp_male_shuichiro': {'name': '修一朗 (Shuichiro)', 'language': 'ja-JP', 'category': 'standard'}, # works
+    'jp_female_rei': {'name': '丸山礼 (Maruyama Rei)', 'language': 'ja-JP', 'category': 'standard'}, # works
+    'jp_male_hikakin': {'name': 'ヒカキン (Hikakin)', 'language': 'ja-JP', 'category': 'standard'}, # works
+    'jp_female_yagishaki': {'name': '八木沙季 (Yagi Saki)', 'language': 'ja-JP', 'category': 'standard'}, # not working
+
+    # Korean Voices
+    'kr_002': {'name': 'Korean Male 1', 'language': 'ko-KR', 'category': 'standard'}, # not working
+    'kr_004': {'name': 'Korean Male 2', 'language': 'ko-KR', 'category': 'standard'}, # not working
+    'kr_003': {'name': 'Korean Female', 'language': 'ko-KR', 'category': 'standard'}, # not working
+
+    # Portuguese Voices
+    'br_003': {'name': 'Júlia', 'language': 'pt-BR', 'category': 'standard'}, # not working
+    'br_004': {'name': 'Ana', 'language': 'pt-BR', 'category': 'standard'}, # not working
+    'br_005': {'name': 'Lucas', 'language': 'pt-BR', 'category': 'standard'}, # not working
+    'pt_female_lhays': {'name': 'Lhays Macedo', 'language': 'pt-PT', 'category': 'standard'}, # works
+    'pt_female_laizza': {'name': 'Laizza', 'language': 'pt-PT', 'category': 'standard'}, # works
+    'pt_male_transformer': {'name': 'Optimus Prime (Portuguese)', 'language': 'pt-PT', 'category': 'character'}, # not working
+
+    # Spanish Voices
+    'es_002': {'name': 'Spanish Male', 'language': 'es-ES', 'category': 'standard'}, # not working
+    'es_male_m3': {'name': 'Julio', 'language': 'es-ES', 'category': 'standard'}, # works
+    'es_female_f6': {'name': 'Alejandra', 'language': 'es-ES', 'category': 'standard'}, # works
+    'es_female_fp1': {'name': 'Mariana', 'language': 'es-ES', 'category': 'standard'}, # works
+    'es_mx_002': {'name': 'Álex (Warm)', 'language': 'es-MX', 'category': 'standard'}, # not working
+    'es_mx_male_transformer': {'name': 'Optimus Prime (Mexican)', 'language': 'es-MX', 'category': 'character'}, # not working
+    'es_mx_female_supermom': {'name': 'Super Mamá', 'language': 'es-MX', 'category': 'character'} # not working
 }

--- a/config.py
+++ b/config.py
@@ -1,0 +1,18 @@
+MODEL_MAPPING = {
+    "keyless-gpt-4o-mini": "gpt-4o-mini",
+    "keyless-claude-3-haiku": "claude-3-haiku-20240307",
+    "keyless-mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "keyless-meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
+}
+VOICES = {
+
+    'en_us_ghostface': {'name': 'Ghost Face', 'language': 'en-US', 'category': 'disney'},
+    'en_us_chewbacca': {'name': 'Chewbacca', 'language': 'en-US', 'category': 'disney'},
+    'en_us_c3po': {'name': 'C3PO', 'language': 'en-US', 'category': 'disney'},
+    'en_us_stitch': {'name': 'Stitch', 'language': 'en-US', 'category': 'disney'},
+    'en_us_stormtrooper': {'name': 'Stormtrooper', 'language': 'en-US', 'category': 'disney'},
+    'en_us_rocket': {'name': 'Rocket', 'language': 'en-US', 'category': 'disney'},
+    'en_female_leota': {'name': 'Madame Leota', 'language': 'en-US', 'category': 'disney'},
+    'en_male_ghosthost': {'name': 'Ghost Host', 'language': 'en-US', 'category': 'disney'},
+    'en_male_pirate': {'name': 'Pirate', 'language': 'en-US', 'category': 'disney'},
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   keyless-gpt-wrapper-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,6 @@ services:
     container_name: keyless
     ports:
       - "1337:1337"
+    environment:
+    #  - TIKTOK_SESSION_ID=  # Optional TTS endpoint functionality
     restart: unless-stopped

--- a/models.py
+++ b/models.py
@@ -1,0 +1,76 @@
+from pydantic import BaseModel
+from typing import List, Dict, Optional, Union
+import time
+
+class AudioConfig(BaseModel):
+    voice: str = "alloy"
+    format: str = "wav"
+
+class AudioData(BaseModel):
+    id: Optional[str] = None
+    expires_at: Optional[int] = None
+    data: Optional[str] = None
+    transcript: Optional[str] = None
+
+
+class ModelInfo(BaseModel):
+    id: str
+    object: str = "model"
+    created: int = int(time.time())
+    owned_by: str = "custom"
+
+class ChatMessage(BaseModel):
+    role: str
+    content: Optional[str] = None
+    audio: Optional[AudioData] = None
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: List[ChatMessage]
+    temperature: Optional[float] = 1.0
+    top_p: Optional[float] = 1.0
+    n: Optional[int] = 1
+    stream: Optional[bool] = False
+    stop: Optional[Union[str, List[str]]] = None
+    max_tokens: Optional[int] = None
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
+    logit_bias: Optional[Dict[str, float]] = None
+    user: Optional[str] = None
+    modalities: Optional[List[str]] = None
+    audio: Optional[AudioConfig] = None
+
+class ChatCompletionResponseChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+class ChatCompletionResponseUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: List[ChatCompletionResponseChoice]
+    usage: Optional[Dict[str, int]] = None
+
+class DeltaMessage(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+class ChatCompletionStreamResponseChoice(BaseModel):
+    index: int
+    delta: DeltaMessage
+    finish_reason: Optional[str] = None
+
+class ChatCompletionStreamResponse(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: List[ChatCompletionStreamResponseChoice]
+

--- a/server.py
+++ b/server.py
@@ -67,14 +67,22 @@ async def chat_with_duckduckgo(query: str, model: str, conversation_history: Lis
 
     # If there is a system message, add it before the first user message (DDG AI doesnt let us send system messages, so this is a workaround -- fundamentally, it works the same way when setting a system prompt)
     system_message = next((msg for msg in conversation_history if msg.role == "system"), None)
-    user_messages = [{"role": msg.role, "content": msg.content} for msg in conversation_history if msg.role == "user"]
     
-    if system_message and user_messages:
-        user_messages[0]["content"] = f"{system_message.content}\n\n{user_messages[0]['content']}"
+    # turns out i did not add in the partial context fixes from last release
+    messages = []
+    if system_message:
+        messages.append({"role": "user", "content": system_message.content})
+
+    for msg in conversation_history:
+        if msg.role in ["user", "assistant"]:
+            messages.append({
+                "role": "user", 
+                "content": msg.content
+            })
 
     payload = {
-        "messages": user_messages,
-        "model": original_model
+        "model": original_model,
+        "messages": messages
     }
 
     headers = {

--- a/tts.py
+++ b/tts.py
@@ -1,13 +1,9 @@
 import httpx
 import base64
 import logging
-import os
 from typing import Optional
 from models import BaseModel
-from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
 
 class TTSRequest(BaseModel):
     model: str = "tts-1"
@@ -20,14 +16,19 @@ class TTSEngine:
     _instance: Optional['TTSEngine'] = None
     
     @classmethod
-    def initialize(cls, session_id: Optional[str] = None):
-        """Initialize the TTSEngine with a session ID from parameter, environment variable, or .env file"""
+    def initialize(cls, session_id: Optional[str] = None) -> Optional['TTSEngine']:
         if cls._instance is None:
-            # Priority: passed session_id > environment variable
-            session_id = session_id or os.getenv('TIKTOK_SESSION_ID')
             if not session_id:
-                logging.warning("No TikTok session ID found in environment variables or .env file. TTS functionality will be disabled.")
-            cls._instance = cls(session_id) if session_id else None
+                logging.warning("No TikTok session ID provided. TTS functionality will be disabled.")
+                return None
+            
+            try:
+                cls._instance = cls(session_id)
+                logging.info("TTS Engine initialized successfully")
+            except ValueError as e:
+                logging.error(f"Failed to initialize TTS Engine: {str(e)}")
+                return None
+                
         return cls._instance
     
     @classmethod

--- a/tts.py
+++ b/tts.py
@@ -1,7 +1,7 @@
 import httpx
 import base64
 import logging
-from typing import Optional
+from typing import Optional, List
 from models import BaseModel
 
 
@@ -47,25 +47,102 @@ class TTSEngine:
 
     async def generate_speech(self, text: str, voice: str = "en_us_002") -> bytes:
         try:
-            sanitized_text = TextProcessor.sanitize_text(text)
-            url = f"https://api16-normal-useast5.us.tiktokv.com/media/api/text/speech/invoke/?text_speaker={voice}&req_text={sanitized_text}&speaker_map_type=0&aid=1233"
+            # Split text into chunks
+            chunks = self._split_text(text)
+            logging.info(f"Split text into {len(chunks)} chunks")
             
-            async with httpx.AsyncClient() as client:
-                response = await client.post(url, headers=self.headers)
-                response_data = response.json()
-                
-                if response_data.get("message") == "Couldn't load speech. Try again.":
-                    raise ValueError("Invalid session ID")
+            all_audio = bytearray()
+            
+            for i, chunk in enumerate(chunks, 1):
+                try:
+                    sanitized_text = TextProcessor.sanitize_text(chunk)
+                    url = f"https://api16-normal-useast5.us.tiktokv.com/media/api/text/speech/invoke/?text_speaker={voice}&req_text={sanitized_text}&speaker_map_type=0&aid=1233"
+                    
+                    logging.info(f"Processing chunk {i}/{len(chunks)} of length {len(chunk)}")
+                    logging.info(f"Sanitized text: {sanitized_text[:50]}...")
+                    
+                    async with httpx.AsyncClient() as client:
+                        response = await client.post(url, headers=self.headers)
+                        #logging.info(f"TikTok API response status for chunk {i}: {response.status_code}")
+                        
+                        response_data = response.json()
+                        #logging.info(f"TikTok API response for chunk {i}: {response_data}")
+                        
+                        if response_data.get("message") == "Couldn't load speech. Try again.":
+                            raise ValueError("Invalid session ID")
 
-                if 'data' not in response_data or 'v_str' not in response_data['data']:
-                    error_msg = response_data.get('message', 'Unknown error occurred')
-                    raise ValueError(f"TikTok API error: {error_msg}")
+                        if response_data.get("status_code") == 2:
+                            logging.warning(f"Chunk {i} too long, attempting to split further")
+                            # Recursively try with smaller chunks
+                            smaller_chunks = self._split_text(chunk, max_size=len(chunk) // 2)
+                            for small_chunk in smaller_chunks:
+                                small_chunk_audio = await self.generate_speech(small_chunk, voice)
+                                all_audio.extend(small_chunk_audio)
+                            continue
 
-                return base64.b64decode(response_data["data"]["v_str"])
+                        if 'data' not in response_data or 'v_str' not in response_data['data']:
+                            error_msg = response_data.get('message', 'Unknown error occurred')
+                            raise ValueError(f"TikTok API error: {error_msg}")
+
+                        chunk_audio = base64.b64decode(response_data["data"]["v_str"])
+                        logging.info(f"Received audio data for chunk {i}, length: {len(chunk_audio)} bytes")
+                        all_audio.extend(chunk_audio)
+                        
+                except Exception as e:
+                    logging.error(f"Error processing chunk {i}: {str(e)}")
+                    raise
+
+            logging.info(f"Successfully generated audio for all chunks. Total size: {len(all_audio)} bytes")
+            return bytes(all_audio)
                 
         except Exception as e:
-            logging.error(f"Speech generation failed: {str(e)}")
+            logging.error(f"Speech generation failed: {str(e)}", exc_info=True)
             raise
+
+    def _split_text(self, text: str, max_size: int = 200) -> List[str]:
+        paragraphs = text.split('\n')
+        chunks = []
+        current_chunk = ""
+        
+        for paragraph in paragraphs:
+            # Split paragraph into sentences
+            sentences = [s.strip() + '.' for s in paragraph.split('.') if s.strip()]
+            
+            for sentence in sentences:
+                # If this sentence alone is longer than max_size, split it by commas
+                if len(sentence) > max_size:
+                    comma_parts = [p.strip() + ',' for p in sentence.split(',') if p.strip()]
+                    for part in comma_parts:
+                        if len(current_chunk) + len(part) > max_size:
+                            if current_chunk:
+                                chunks.append(current_chunk.strip())
+                            current_chunk = part
+                        else:
+                            current_chunk += " " + part
+                else:
+                    # If adding this sentence would exceed the limit, start a new chunk
+                    if len(current_chunk) + len(sentence) > max_size:
+                        if current_chunk:
+                            chunks.append(current_chunk.strip())
+                        current_chunk = sentence
+                    else:
+                        current_chunk += " " + sentence
+            
+            # Add paragraph break if not at the end
+            if current_chunk:
+                chunks.append(current_chunk.strip())
+                current_chunk = ""
+        
+        # Add the last chunk if it's not empty
+        if current_chunk:
+            chunks.append(current_chunk.strip())
+        
+        # Filter out empty chunks and strip whitespace
+        chunks = [chunk.strip() for chunk in chunks if chunk.strip()]
+        
+        logging.info(f"Split text into {len(chunks)} chunks: {[len(c) for c in chunks]} chars each")
+        return chunks
+
 
 class TextProcessor:
     @staticmethod

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,59 @@
+import httpx
+import base64
+import logging
+from models import BaseModel
+
+
+class TTSRequest(BaseModel):
+    model: str = "tts-1"
+    input: str
+    voice: str = "en_us_002"
+    response_format: str = "mp3"
+    speed: float = 1.0
+
+class TTSEngine:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.headers = {
+            'User-Agent': "com.zhiliaoapp.musically/2022600030 (Linux; U; Android 7.1.2; es_ES; SM-G988N; Build/NRD90M;tt-ok/3.12.13.1)",
+            'Cookie': f'sessionid={session_id}'
+        }
+
+    async def generate_speech(self, text: str, voice: str = "en_us_002") -> bytes:
+        try:
+            sanitized_text = TextProcessor.sanitize_text(text)
+            url = f"https://api16-normal-useast5.us.tiktokv.com/media/api/text/speech/invoke/?text_speaker={voice}&req_text={sanitized_text}&speaker_map_type=0&aid=1233"
+            
+            async with httpx.AsyncClient() as client:
+                response = await client.post(url, headers=self.headers)
+                response_data = response.json()
+                
+                if response_data.get("message") == "Couldn't load speech. Try again.":
+                    raise ValueError("Invalid session ID")
+
+                if 'data' not in response_data or 'v_str' not in response_data['data']:
+                    error_msg = response_data.get('message', 'Unknown error occurred')
+                    raise ValueError(f"TikTok API error: {error_msg}")
+
+                return base64.b64decode(response_data["data"]["v_str"])
+                
+        except Exception as e:
+            logging.error(f"Speech generation failed: {str(e)}")
+            raise
+
+class TextProcessor:
+    @staticmethod
+    def sanitize_text(text: str) -> str:
+        replacements = {
+            "+": "plus",
+            " ": "+",
+            "&": "and",
+            "ä": "ae",
+            "ö": "oe",
+            "ü": "ue",
+            "ß": "ss",
+            "\n": ""
+        }
+        for old, new in replacements.items():
+            text = text.replace(old, new)
+        return text


### PR DESCRIPTION
This PR adds in two additional, **yet completely optional routes**

- /v1/audio/speech/
- /v1/audio/speech/voices

These routes utilize TikTok's Text to Speech endpoints to generate voices based on a given user's input or an LLM's response. This addition was based on [OpenAI's Speech API endpoint](https://platform.openai.com/docs/guides/audio) so it can remain compatible with AI tools that can use Text To Speech, like Open Web UI.

Using these routes are disabled by default as they require a TikTok Session ID, all of which I outlined in the Wiki.
The website has been updated to reflect these changes

Again, this is disabled by default and is completely optional.


Also important addition:

Turns out I did not ship the bug fix that fixes the partial context bug, which was a giant oversight on my part, this comes included in the PR too