### PR TITLE
Update llama3.1 --> llama3.3

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ MODEL_MAPPING = {
     "keyless-gpt-o3-mini": "o3-mini",
     "keyless-claude-3-haiku": "claude-3-haiku-20240307",
     "keyless-mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-    "keyless-meta-Llama-3.1-70B-Instruct-Turbo": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
+    "keyless-meta-Llama-3.3-70B-Instruct-Turbo": "meta-llama/Llama-3.3-70B-Instruct-Turbo"
 }
 VOICES = {
     # English Voices - Standard


### PR DESCRIPTION
DDG Chat in addition to adding in o3-mini support, also has updated its llama model to use llama3.3 instead of 3.1. This PR reflects that change.